### PR TITLE
Add common_prefix_match

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -154,12 +154,40 @@ mod trie {
             },
         );
     }
+    pub fn common_prefix_match(_: &mut Criterion) {
+        let times = 100;
+
+        super::c().bench_function(
+            &format!(
+                "[{}] Trie::common_prefix_match() {} times",
+                super::git_hash(),
+                times
+            ),
+            move |b| {
+                b.iter_batched(
+                    || &TRIE_EDICT,
+                    |trie| {
+                        // iter_batched() does not properly time `routine` time when `setup` time is far longer than `routine` time.
+                        // Tested function takes too short compared to build(). So loop many times.
+                        let result = trie.common_prefix_match("すしをにぎる");
+                        for _ in 0..(times - 1) {
+                            trie.common_prefix_match("すしをにぎる");
+                        }
+
+                        assert_eq!(result, true);
+                    },
+                    BatchSize::SmallInput,
+                )
+            },
+        );
+    }
 }
 
 criterion_group!(
     benches,
     trie::exact_match,
     trie::predictive_search,
-    trie::common_prefix_search
+    trie::common_prefix_search,
+    trie::common_prefix_match
 );
 criterion_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,9 @@
 //!         "すしや",
 //!     ]  // Sorted by `Vec<u8>`'s order
 //! );
+//!
+//! // common_prefix_match(): Check if there's at least one word with `query` prefix.
+//! assert_eq!(trie.common_prefix_match("すしや"), true);
 //! ```
 //!
 //! ## Using with Various Data Types
@@ -122,6 +125,10 @@
 //!     trie.common_prefix_search(vec!["a", "woman", "on", "the", "beach"]),
 //!     vec![vec!["a", "woman"], vec!["a", "woman", "on", "the", "beach"]],
 //! );
+//! assert_eq!(
+//!     trie.common_prefix_match(vec!["a", "woman", "on", "the", "beach"]),
+//!     true,
+//! );
 //! ```
 //!
 //! ### `Label=u8, Arr=[u8; n]`
@@ -160,6 +167,10 @@
 //! assert_eq!(
 //!     trie.common_prefix_search([1, 4, 1, 5, 9, 2, 6, 5, 3, 5]),
 //!     vec![[1, 4, 1, 5, 9, 2, 6, 5, 3, 5]],
+//! );
+//! assert_eq!(
+//!     trie.common_prefix_match([1, 4, 1, 5, 9, 2, 6, 5, 3, 5]),
+//!     true,
 //! );
 //! ```
 //!

--- a/src/trie/trie.rs
+++ b/src/trie/trie.rs
@@ -67,6 +67,26 @@ impl<Label: Ord + Clone> Trie<Label> {
         results
     }
 
+    pub fn common_prefix_match<Arr: AsRef<[Label]>>(&self, query: Arr) -> bool {
+        let mut cur_node_num = LoudsNodeNum(1);
+
+        for chr in query.as_ref() {
+            let children_node_nums = self.children_node_nums(cur_node_num);
+            let res = self.bin_search_by_children_labels(chr, &children_node_nums[..]);
+            match res {
+                Ok(j) => {
+                    let child_node_num = children_node_nums[j];
+                    if self.is_terminal(child_node_num) {
+                        return true;
+                    };
+                    cur_node_num = child_node_num;
+                }
+                Err(_) => break,
+            }
+        }
+        false
+    }
+
     pub fn common_prefix_search<Arr: AsRef<[Label]>>(&self, query: Arr) -> Vec<Vec<Label>> {
         let mut results: Vec<Vec<Label>> = Vec::new();
         let mut labels_in_path: Vec<Label> = Vec::new();


### PR DESCRIPTION
Hey!
Running this code instead of `common_prefix_search.is_empty()` is ~18% faster for my use case (which is matching a trie with \~3500 items, of 5\~40 chars each

Not sure if it's worth adding to the crate though..

Running the benchmark on my pc, 
```
Benchmarking [fab7d8c] Trie::common_prefix_search() 100 times: Analyzing
[fab7d8c] Trie::common_prefix_search() 100 times
                        time:   [3.1533 ms 3.1587 ms 3.1684 ms]

[fab7d8c] Trie::common_prefix_match() 100 times
                        time:   [732.60 us 734.58 us 736.95 us]
```