### PR TITLE
Add Key Value support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/laysakura/trie-rs"
 homepage = "https://github.com/laysakura/trie-rs"
 keywords = ["trie", "louds", "succinct"] # up to 5 keywords, each keyword should have <= 20 chars
 categories = ["compression", "data-structures"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 louds-rs = "0.4"

--- a/src/internal_data_structure/naive_trie.rs
+++ b/src/internal_data_structure/naive_trie.rs
@@ -45,9 +45,9 @@ pub mod naive_trie_b_f_iter;
 ///                                  | n
 ///                                <IntermOrLeaf (Terminate)>
 /// ```
-pub enum NaiveTrie<Label> {
-    Root(Box<NaiveTrieRoot<Label>>),
-    IntermOrLeaf(Box<NaiveTrieIntermOrLeaf<Label>>),
+pub enum NaiveTrie<K, V> {
+    Root(NaiveTrieRoot<K, V>),
+    IntermOrLeaf(Box<NaiveTrieIntermOrLeaf<K, V>>),
 
     /// Used for Breadth-First iteration.
     ///
@@ -72,14 +72,15 @@ pub enum NaiveTrie<Label> {
     PhantomSibling,
 }
 
-pub struct NaiveTrieRoot<Label> {
+pub struct NaiveTrieRoot<K, V> {
     /// Sorted by Label's order.
-    children: Vec<Box<NaiveTrie<Label>>>,
+    children: Vec<NaiveTrie<K, V>>,
 }
 
-pub struct NaiveTrieIntermOrLeaf<Label> {
+pub struct NaiveTrieIntermOrLeaf<K, V> {
     /// Sorted by Label's order.
-    children: Vec<Box<NaiveTrie<Label>>>,
-    label: Label,
+    children: Vec<NaiveTrie<K, V>>,
+    key: K,
+    value: V,
     is_terminal: bool,
 }

--- a/src/internal_data_structure/naive_trie.rs
+++ b/src/internal_data_structure/naive_trie.rs
@@ -45,6 +45,7 @@ pub mod naive_trie_b_f_iter;
 ///                                  | n
 ///                                <IntermOrLeaf (Terminate)>
 /// ```
+#[derive(Debug, Clone)]
 pub enum NaiveTrie<K, V> {
     Root(NaiveTrieRoot<K, V>),
     IntermOrLeaf(Box<NaiveTrieIntermOrLeaf<K, V>>),
@@ -72,11 +73,13 @@ pub enum NaiveTrie<K, V> {
     PhantomSibling,
 }
 
+#[derive(Debug, Clone)]
 pub struct NaiveTrieRoot<K, V> {
     /// Sorted by Label's order.
     children: Vec<NaiveTrie<K, V>>,
 }
 
+#[derive(Debug, Clone)]
 pub struct NaiveTrieIntermOrLeaf<K, V> {
     /// Sorted by Label's order.
     children: Vec<NaiveTrie<K, V>>,

--- a/src/internal_data_structure/naive_trie/naive_trie_b_f_iter.rs
+++ b/src/internal_data_structure/naive_trie/naive_trie_b_f_iter.rs
@@ -2,20 +2,20 @@ use super::NaiveTrie;
 use std::collections::VecDeque;
 
 /// Iterates over NaiveTrie in Breadth-First manner.
-pub struct NaiveTrieBFIter<'trie, Label> {
-    unvisited: VecDeque<&'trie NaiveTrie<Label>>,
+pub struct NaiveTrieBFIter<'trie, K, V> {
+    unvisited: VecDeque<&'trie NaiveTrie<K, V>>,
 }
 
-impl<'trie, Label> NaiveTrieBFIter<'trie, Label> {
-    pub fn new(iter_start: &'trie NaiveTrie<Label>) -> Self {
+impl<'trie, K, V> NaiveTrieBFIter<'trie, K, V> {
+    pub fn new(iter_start: &'trie NaiveTrie<K, V>) -> Self {
         let mut unvisited = VecDeque::new();
         unvisited.push_back(iter_start);
         Self { unvisited }
     }
 }
 
-impl<'trie, Label: Ord + Clone> Iterator for NaiveTrieBFIter<'trie, Label> {
-    type Item = &'trie NaiveTrie<Label>;
+impl<'trie, K: Ord + Clone, V: Clone> Iterator for NaiveTrieBFIter<'trie, K, V> {
+    type Item = &'trie NaiveTrie<K, V>;
 
     /// Returns:
     ///
@@ -51,9 +51,9 @@ mod bf_iter_tests {
                 let (words, expected_nodes) = $value;
                 let mut trie = NaiveTrie::make_root();
                 for word in words {
-                    trie.push(word);
+                    trie.push(word, 0);
                 }
-                let nodes: Vec<&NaiveTrie<u8>> = trie.bf_iter().collect();
+                let nodes: Vec<&NaiveTrie<u8, u8>> = trie.bf_iter().collect();
                 assert_eq!(nodes.len(), expected_nodes.len());
                 for i in 0..nodes.len() {
                     let node = nodes[i];
@@ -62,7 +62,7 @@ mod bf_iter_tests {
                     assert!(std::mem::discriminant(node) == std::mem::discriminant(expected_node));
 
                     if let NaiveTrie::IntermOrLeaf(n) = node {
-                        assert_eq!(n.label, expected_node.label());
+                        assert_eq!(n.key, expected_node.label());
                         assert_eq!(n.is_terminal, expected_node.is_terminal());
                     }
                 }
@@ -85,7 +85,7 @@ mod bf_iter_tests {
             vec![
                 NaiveTrie::make_root(),
                 // parent = root
-                NaiveTrie::make_interm_or_leaf(&('a' as u8), true),
+                NaiveTrie::make_interm_or_leaf(&('a' as u8), 0, true),
                 NaiveTrie::PhantomSibling,
                 // parent = a
                 NaiveTrie::PhantomSibling,
@@ -96,7 +96,7 @@ mod bf_iter_tests {
             vec![
                 NaiveTrie::make_root(),
                 // parent = root
-                NaiveTrie::make_interm_or_leaf(&('a' as u8), true),
+                NaiveTrie::make_interm_or_leaf(&('a' as u8), 0 , true),
                 NaiveTrie::PhantomSibling,
                 // parent = a
                 NaiveTrie::PhantomSibling,
@@ -120,19 +120,19 @@ mod bf_iter_tests {
             vec![
                 NaiveTrie::make_root(),
                 // parent = root
-                NaiveTrie::make_interm_or_leaf(&('a' as u8), true),
-                NaiveTrie::make_interm_or_leaf(&('b' as u8), false),
+                NaiveTrie::make_interm_or_leaf(&('a' as u8), 0,  true),
+                NaiveTrie::make_interm_or_leaf(&('b' as u8), 0, false),
                 NaiveTrie::PhantomSibling,
                 // parent = [a]
-                NaiveTrie::make_interm_or_leaf(&('n' as u8), true),
+                NaiveTrie::make_interm_or_leaf(&('n' as u8), 0,  true),
                 NaiveTrie::PhantomSibling,
                 // parent = b
-                NaiveTrie::make_interm_or_leaf(&('a' as u8), false),
+                NaiveTrie::make_interm_or_leaf(&('a' as u8), 0, false),
                 NaiveTrie::PhantomSibling,
                 // parent = n
                 NaiveTrie::PhantomSibling,
                 // parent = b[a]d
-                NaiveTrie::make_interm_or_leaf(&('d' as u8), true),
+                NaiveTrie::make_interm_or_leaf(&('d' as u8), 0, true),
                 NaiveTrie::PhantomSibling,
                 // parent = d
                 NaiveTrie::PhantomSibling,
@@ -146,52 +146,52 @@ mod bf_iter_tests {
             vec![
                 NaiveTrie::make_root(),
                 // parent = root
-                NaiveTrie::make_interm_or_leaf(&('a' as u8), true),
-                NaiveTrie::make_interm_or_leaf(&227, false),
+                NaiveTrie::make_interm_or_leaf(&('a' as u8), 0, true),
+                NaiveTrie::make_interm_or_leaf(&227, 0, false),
                 NaiveTrie::PhantomSibling,
                 // parent = a
-                NaiveTrie::make_interm_or_leaf(&('n' as u8), true),
+                NaiveTrie::make_interm_or_leaf(&('n' as u8), 0, true),
                 NaiveTrie::PhantomSibling,
                 // parent = [227] 130 138 (り)
-                NaiveTrie::make_interm_or_leaf(&130, false),
+                NaiveTrie::make_interm_or_leaf(&130, 0, false),
                 NaiveTrie::PhantomSibling,
                 // parent = n
                 NaiveTrie::PhantomSibling,
                 // parent = 227 [130] 138 (り)
-                NaiveTrie::make_interm_or_leaf(&138, false),
+                NaiveTrie::make_interm_or_leaf(&138, 0, false),
                 NaiveTrie::PhantomSibling,
                 // parent = 227 130 [138] (り)
-                NaiveTrie::make_interm_or_leaf(&227, false),
+                NaiveTrie::make_interm_or_leaf(&227, 0, false),
                 NaiveTrie::PhantomSibling,
                 // parent = [227] 130 147 (ん)
-                NaiveTrie::make_interm_or_leaf(&130, false),
+                NaiveTrie::make_interm_or_leaf(&130, 0, false),
                 NaiveTrie::PhantomSibling,
                 // parent = 227 [130] 147 (ん)
-                NaiveTrie::make_interm_or_leaf(&147, false),
+                NaiveTrie::make_interm_or_leaf(&147, 0, false),
                 NaiveTrie::PhantomSibling,
                 // parent = 227 130 [147] (ん)
-                NaiveTrie::make_interm_or_leaf(&227, false),
+                NaiveTrie::make_interm_or_leaf(&227, 0, false),
                 NaiveTrie::PhantomSibling,
                 // parent = [227] _ _ (ご or り)
-                NaiveTrie::make_interm_or_leaf(&129, false),
-                NaiveTrie::make_interm_or_leaf(&130, false),
+                NaiveTrie::make_interm_or_leaf(&129,0, false),
+                NaiveTrie::make_interm_or_leaf(&130,0, false),
                 NaiveTrie::PhantomSibling,
                 // parent = 227 [129] 148 (ご)
-                NaiveTrie::make_interm_or_leaf(&148, true),
+                NaiveTrie::make_interm_or_leaf(&148,0, true),
                 NaiveTrie::PhantomSibling,
                 // parent = 227 [130] 138 (り)
-                NaiveTrie::make_interm_or_leaf(&138, false),
+                NaiveTrie::make_interm_or_leaf(&138, 0, false),
                 NaiveTrie::PhantomSibling,
                 // parent = 227 129 [148] (ご)
                 NaiveTrie::PhantomSibling,
                 // parent = 227 130 [138] (り)
-                NaiveTrie::make_interm_or_leaf(&227, false),
+                NaiveTrie::make_interm_or_leaf(&227, 0, false),
                 NaiveTrie::PhantomSibling,
                 // parent = [227] 130 147 (ん)
-                NaiveTrie::make_interm_or_leaf(&130, false),
+                NaiveTrie::make_interm_or_leaf(&130,0, false),
                 NaiveTrie::PhantomSibling,
                 // parent = 227 [130] 147 (ん)
-                NaiveTrie::make_interm_or_leaf(&147, true),
+                NaiveTrie::make_interm_or_leaf(&147, 0, true),
                 NaiveTrie::PhantomSibling,
                 // parent = 227 130 [147] (ん)
                 NaiveTrie::PhantomSibling,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,14 +30,14 @@
 //! use trie_rs::TrieBuilder;
 //!
 //! let mut builder = TrieBuilder::new();  // Inferred `TrieBuilder<u8>` automatically
-//! builder.push("すし");
-//! builder.push("すしや");
-//! builder.push("すしだね");
-//! builder.push("すしづめ");
-//! builder.push("すしめし");
-//! builder.push("すしをにぎる");
-//! builder.push("すし");  // Word `push`ed twice is just ignored.
-//! builder.push("🍣");
+//! builder.push("すし", 1);
+//! builder.push("すしや", 2);
+//! builder.push("すしだね", 3);
+//! builder.push("すしづめ", 4);
+//! builder.push("すしめし", 5);
+//! builder.push("すしをにぎる", 6);
+//! builder.push("すし", 7);  // Word `push`ed twice is just ignored.
+//! builder.push("🍣", 8);
 //!
 //! let trie = builder.build();
 //!
@@ -101,9 +101,9 @@
 //! use trie_rs::TrieBuilder;
 //!
 //! let mut builder = TrieBuilder::new();
-//! builder.push(vec!["a", "woman"]);
-//! builder.push(vec!["a", "woman", "on", "the", "beach"]);
-//! builder.push(vec!["a", "woman", "on", "the", "run"]);
+//! builder.push(vec!["a", "woman"], 0 );
+//! builder.push(vec!["a", "woman", "on", "the", "beach"], 1);
+//! builder.push(vec!["a", "woman", "on", "the", "run"], 2);
 //!
 //! let trie = builder.build();
 //!
@@ -130,22 +130,22 @@
 //! ```rust
 //! use trie_rs::TrieBuilder;
 //!
-//! let mut builder = TrieBuilder::<u8>::new(); // Pi = 3.14...
+//! let mut builder = TrieBuilder::<u8, u8>::new(); // Pi = 3.14...
 //!
-//! builder.push([1, 4, 1, 5, 9, 2, 6, 5, 3, 5]);
-//! builder.push([8, 9, 7, 9, 3, 2, 3, 8, 4, 6]);
-//! builder.push([2, 6, 4, 3, 3, 8, 3, 2, 7, 9]);
-//! builder.push([6, 9, 3, 9, 9, 3, 7, 5, 1, 0]);
-//! builder.push([5, 8, 2, 0, 9, 7, 4, 9, 4, 4]);
-//! builder.push([5, 9, 2, 3, 0, 7, 8, 1, 6, 4]);
-//! builder.push([0, 6, 2, 8, 6, 2, 0, 8, 9, 9]);
-//! builder.push([8, 6, 2, 8, 0, 3, 4, 8, 2, 5]);
-//! builder.push([3, 4, 2, 1, 1, 7, 0, 6, 7, 9]);
-//! builder.push([8, 2, 1, 4, 8, 0, 8, 6, 5, 1]);
-//! builder.push([3, 2, 8, 2, 3, 0, 6, 6, 4, 7]);
-//! builder.push([0, 9, 3, 8, 4, 4, 6, 0, 9, 5]);
-//! builder.push([5, 0, 5, 8, 2, 2, 3, 1, 7, 2]);
-//! builder.push([5, 3, 5, 9, 4, 0, 8, 1, 2, 8]);
+//! builder.push([1, 4, 1, 5, 9, 2, 6, 5, 3, 5], 1);
+//! builder.push([8, 9, 7, 9, 3, 2, 3, 8, 4, 6], 2);
+//! builder.push([2, 6, 4, 3, 3, 8, 3, 2, 7, 9], 3);
+//! builder.push([6, 9, 3, 9, 9, 3, 7, 5, 1, 0], 4);
+//! builder.push([5, 8, 2, 0, 9, 7, 4, 9, 4, 4], 5);
+//! builder.push([5, 9, 2, 3, 0, 7, 8, 1, 6, 4], 6);
+//! builder.push([0, 6, 2, 8, 6, 2, 0, 8, 9, 9], 7);
+//! builder.push([8, 6, 2, 8, 0, 3, 4, 8, 2, 5], 8);
+//! builder.push([3, 4, 2, 1, 1, 7, 0, 6, 7, 9], 9);
+//! builder.push([8, 2, 1, 4, 8, 0, 8, 6, 5, 1], 10);
+//! builder.push([3, 2, 8, 2, 3, 0, 6, 6, 4, 7], 11);
+//! builder.push([0, 9, 3, 8, 4, 4, 6, 0, 9, 5], 12);
+//! builder.push([5, 0, 5, 8, 2, 2, 3, 1, 7, 2], 13);
+//! builder.push([5, 3, 5, 9, 4, 0, 8, 1, 2, 8], 14);
 //!
 //! let trie = builder.build();
 //!

--- a/src/trie.rs
+++ b/src/trie.rs
@@ -11,6 +11,7 @@ pub struct Trie<K, V> {
     trie_labels: Vec<TrieLabel<K, V>>,
 }
 
+#[derive(Debug, Clone)]
 pub struct TrieBuilder<K, V> {
     naive_trie: NaiveTrie<K, V>,
 }

--- a/src/trie.rs
+++ b/src/trie.rs
@@ -4,18 +4,19 @@ use louds_rs::Louds;
 pub mod trie;
 pub mod trie_builder;
 
-pub struct Trie<Label> {
+pub struct Trie<K, V> {
     louds: Louds,
 
     /// (LoudsNodeNum - 2) -> TrieLabel
-    trie_labels: Vec<TrieLabel<Label>>,
+    trie_labels: Vec<TrieLabel<K, V>>,
 }
 
-pub struct TrieBuilder<Label> {
-    naive_trie: NaiveTrie<Label>,
+pub struct TrieBuilder<K, V> {
+    naive_trie: NaiveTrie<K, V>,
 }
 
-struct TrieLabel<Label> {
-    label: Label,
+struct TrieLabel<K, V> {
+    key: K,
+    value: V,
     is_terminal: bool,
 }

--- a/src/trie/trie_builder.rs
+++ b/src/trie/trie_builder.rs
@@ -3,26 +3,27 @@ use crate::trie::TrieLabel;
 use crate::{Trie, TrieBuilder};
 use louds_rs::Louds;
 
-impl<Label: Ord + Clone> TrieBuilder<Label> {
+impl<K: Ord + Clone, V: Clone> TrieBuilder<K, V> {
     pub fn new() -> Self {
         let naive_trie = NaiveTrie::make_root();
         Self { naive_trie }
     }
 
-    pub fn push<Arr: AsRef<[Label]>>(&mut self, word: Arr) {
-        self.naive_trie.push(word);
+    pub fn push<Key: AsRef<[K]>>(&mut self, key: Key, value: V) {
+        self.naive_trie.push(key, value);
     }
 
-    pub fn build(&self) -> Trie<Label> {
+    pub fn build(&self) -> Trie<K, V> {
         let mut louds_bits: Vec<bool> = vec![true, false];
-        let mut trie_labels: Vec<TrieLabel<Label>> = vec![];
+        let mut trie_labels: Vec<TrieLabel<K, V>> = vec![];
         for node in self.naive_trie.bf_iter() {
             match node {
                 NaiveTrie::Root(_) => {}
                 NaiveTrie::IntermOrLeaf(_) => {
                     louds_bits.push(true);
                     trie_labels.push(TrieLabel {
-                        label: node.label(),
+                        key: node.label().clone(),
+                        value: node.value().clone(),
                         is_terminal: node.is_terminal(),
                     });
                 }


### PR DESCRIPTION
This allows a user of this library to tie a value with the keys set for prefix Trie. The advantage of this is that a caller can call common_prefix_search_with_values to get all the prefix matches along with their values.

Note: This makes a breaking change to builder.push() to accept a K, and a V. I chose to go this way to keep the api simple. Happy to use a different push_with_val() method if that helps. 