### PR TITLE
Latency improvement for predictive_search

### DIFF
--- a/src/trie/trie.rs
+++ b/src/trie/trie.rs
@@ -25,15 +25,8 @@ impl<Label: Ord + Clone> Trie<Label> {
 
     /// # Panics
     /// If `query` is empty.
+    /// Builds a sorted Vec of keys starting with `query` by performing a preorder traversal
     pub fn predictive_search<Arr: AsRef<[Label]>>(&self, query: Arr) -> Vec<Vec<Label>> {
-        self.predictive_search_inner(query)
-    }
-
-    /// builds a set of keys starting with `query` by performing a preorder traversal
-    fn predictive_search_inner<Arr: AsRef<[Label]>>(
-        &self,
-        query: Arr
-    ) -> Vec<Vec<Label>> {
         assert!(!query.as_ref().is_empty());
         let mut cur_node_num = LoudsNodeNum(1);
 


### PR DESCRIPTION
Hi! Thanks for this neat library, I appreciate your work.

If you're open to contributions, this PR changes the implementation of `predictive_search` to perform an iterative preorder traversal of the trie, instead of recursive calls.  In benchmarks on my machine that's about a `45%` reduction in latency. Tests are passing. This is relevant to https://github.com/laysakura/trie-rs/issues/10 .

Relatedly: would you be open to a future PR that returns suggestions as an `Iterator`? The idea being you can do `trie.predictive_suggestions("foo").take(k)` to grab `K` suggestions rather than all of them (and potentially skip some of the work!).