### PR TITLE
Add trie_rs::map::{Trie, TrieBuilder}.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+Add `is_prefix()` and `trie_rs::map::{Trie, TrieBuilder}`.
 
 ## [v0.1.1]
 Only internal data type change.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["compression", "data-structures"]
 edition = "2018"
 
 [dependencies]
+derivative = "2.2.0"
 louds-rs = "0.4"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "trie-rs"
 version = "0.1.2-alpha.0"
-authors = ["Sho Nakatani <lay.sakura@gmail.com>"]
-description = "Memory efficient trie (prefix tree) library based on LOUDS"
+authors = ["Sho Nakatani <lay.sakura@gmail.com>", "Shane Celis <shane.celis@gmail.com>"]
+description = "Memory efficient trie (prefix tree) and map library based on LOUDS"
 readme = "README.md"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/laysakura/trie-rs"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # trie-rs
 
-Memory efficient trie (prefix tree) library based on LOUDS.
+Memory efficient trie (prefix tree) and map library based on LOUDS.
 
 [Master API Docs](https://laysakura.github.io/trie-rs/trie_rs/)
 |
@@ -163,6 +163,32 @@ assert_eq!(
     trie.common_prefix_search([1, 4, 1, 5, 9, 2, 6, 5, 3, 5]),
     vec![[1, 4, 1, 5, 9, 2, 6, 5, 3, 5]],
 );
+```
+
+### Trie Map Usage
+
+To store a value with each word, use `trie_rs::map::{Trie, TrieBuilder}`.
+
+```rust
+use std::str;
+use trie_rs::map::TrieBuilder;
+
+let mut builder = TrieBuilder::new();  // Inferred `TrieBuilder<u8, u8>` automatically
+builder.push("すし", 0);
+builder.push("すしや", 1);
+builder.push("すしだね", 2);
+builder.push("すしづめ", 3);
+builder.push("すしめし", 4);
+builder.push("すしをにぎる", 5);
+builder.push("すし", 6);  // Word `push`ed twice is just ignored.
+builder.push("🍣", 7);
+
+let trie = builder.build();
+
+// exact_match(): Find a word exactly match to query.
+assert_eq!(trie.exact_match("すし"), Some(0));
+assert_eq!(trie.exact_match("🍣"), Some(7));
+assert_eq!(trie.exact_match("🍜"), None);
 ```
 
 ## Features

--- a/src/dict/mod.rs
+++ b/src/dict/mod.rs
@@ -1,0 +1,193 @@
+use crate::{Trie as OldTrie, TrieBuilder as OldTrieBuilder};
+use derivative::Derivative;
+
+#[derive(Derivative, Clone, Debug)]
+#[derivative(Eq, Ord, PartialEq, PartialOrd)]
+struct KeyValue<K,V>(K,
+                     #[derivative(PartialEq="ignore")]
+                     // #[derivative(Eq="ignore")]
+                     #[derivative(PartialOrd="ignore")]
+                     #[derivative(Ord="ignore")]
+                     Option<V>);
+
+
+
+pub struct Trie<K,V>(OldTrie<KeyValue<K,V>>);
+pub struct TrieBuilder<K,V>(OldTrieBuilder<KeyValue<K,V>>);
+
+impl<K: Clone + std::fmt::Debug, V: Clone + std::fmt::Debug> Trie<K,V> where KeyValue<K,V>: Ord + Clone {
+    pub fn exact_match<Arr: AsRef<[K]>>(&self, query: Arr) -> Option<V> {
+        let q: Vec<KeyValue<K,V>> = query.as_ref().iter().map(|x: &K| KeyValue(x.clone(), None)).collect();
+        self.0.exact_match_node(q).and_then(|n| self.0.label(n).1)
+    }
+
+    pub fn is_prefix<Arr: AsRef<[K]>>(&self, query: Arr) -> bool {
+        let q: Vec<KeyValue<K,V>> = query.as_ref().iter().map(|x: &K| KeyValue(x.clone(), None)).collect();
+        self.0.is_prefix(q)
+    }
+
+    pub fn predictive_search<Arr: AsRef<[K]>>(&self, query: Arr) -> Vec<(Vec<K>, V)> {
+        let q: Vec<KeyValue<K,V>> = query.as_ref().iter().map(|x: &K| KeyValue(x.clone(), None)).collect();
+        self.0.predictive_search(q).into_iter().map(|v| Self::strip(v)).collect()
+    }
+
+    pub fn common_prefix_search<Arr: AsRef<[K]>>(&self, query: Arr) -> Vec<(Vec<K>, V)> {
+        let q: Vec<KeyValue<K,V>> = query.as_ref().iter().map(|x: &K| KeyValue(x.clone(), None)).collect();
+        self.0.common_prefix_search(q).into_iter().map(|v| Self::strip(v)).collect()
+    }
+
+    fn strip(mut word: Vec<KeyValue<K,V>>) -> (Vec<K>, V) {
+        let value = word.last_mut().unwrap().1.clone().map(|x| x.clone()).unwrap();
+        (word.into_iter().map(|x| x.0).collect(), value)
+    }
+}
+
+impl<K: Clone + std::fmt::Debug, V: Clone + std::fmt::Debug> TrieBuilder<K,V> where KeyValue<K,V>: Ord + Clone {
+
+    pub fn new() -> Self {
+        Self(OldTrieBuilder::new())
+    }
+
+    pub fn push<Arr: AsRef<[K]>>(&mut self, word: Arr, value: V) {
+        let mut v: Vec<KeyValue<K,V>> = word.as_ref().iter().map(|x: &K| KeyValue(x.clone(), None)).collect();
+        v.last_mut().unwrap().1 = Some(value);
+        self.0.push(v);
+    }
+
+    pub fn build(&self) -> Trie<K,V> {
+        Trie(self.0.build())
+    }
+}
+
+#[cfg(test)]
+mod search_tests {
+    use super::{Trie, TrieBuilder};
+
+    fn build_trie() -> Trie<u8, u8> {
+        let mut builder = TrieBuilder::new();
+        builder.push("a", 0);
+        builder.push("app", 1);
+        builder.push("apple", 2);
+        builder.push("better", 3);
+        builder.push("application", 4);
+        builder.push("アップル🍎", 5);
+        builder.build()
+    }
+
+    #[test]
+    fn sanity_check() {
+        let trie = build_trie();
+        assert_eq!(trie.predictive_search("apple"), vec![("apple".as_bytes().to_vec(), 2)]);
+
+    }
+
+    mod exact_match_tests {
+        macro_rules! parameterized_tests {
+            ($($name:ident: $value:expr,)*) => {
+            $(
+                #[test]
+                fn $name() {
+                    let (query, expected_match) = $value;
+                    let trie = super::build_trie();
+                    let result = trie.exact_match(query);
+                    assert_eq!(result, expected_match);
+                }
+            )*
+            }
+        }
+
+        parameterized_tests! {
+            t1: ("a", Some(0)),
+            t2: ("app", Some(1)),
+            t3: ("apple", Some(2)),
+            t4: ("application", Some(4)),
+            t5: ("better", Some(3)),
+            t6: ("アップル🍎", Some(5)),
+            t7: ("appl", None),
+            t8: ("appler", None),
+        }
+    }
+
+    mod is_prefix_tests {
+        macro_rules! parameterized_tests {
+            ($($name:ident: $value:expr,)*) => {
+            $(
+                #[test]
+                fn $name() {
+                    let (query, expected_match) = $value;
+                    let trie = super::build_trie();
+                    let result = trie.is_prefix(query);
+                    assert_eq!(result, expected_match);
+                }
+            )*
+            }
+        }
+
+        parameterized_tests! {
+            t1: ("a", true),
+            t2: ("app", true),
+            t3: ("apple", false),
+            t4: ("application", false),
+            t5: ("better", false),
+            t6: ("アップル🍎", false),
+            t7: ("appl", true),
+            t8: ("appler", false),
+            t9: ("アップル", true),
+        }
+    }
+
+    mod predictive_search_tests {
+        macro_rules! parameterized_tests {
+            ($($name:ident: $value:expr,)*) => {
+            $(
+                #[test]
+                fn $name() {
+                    let (query, expected_results) = $value;
+                    let trie = super::build_trie();
+                    let results = trie.predictive_search(query);
+                    let expected_results: Vec<(Vec<u8>, u8)> = expected_results.iter().map(|s| (s.0.as_bytes().to_vec(), s.1)).collect();
+                    assert_eq!(results, expected_results);
+                }
+            )*
+            }
+        }
+
+        parameterized_tests! {
+            t1: ("a", vec![("a", 0), ("app", 1), ("apple", 2), ("application", 4)]),
+            t2: ("app", vec![("app", 1), ("apple", 2), ("application", 4)]),
+            t3: ("appl", vec![("apple", 2), ("application", 4)]),
+            t4: ("apple", vec![("apple", 2)]),
+            t5: ("b", vec![("better", 3)]),
+            t6: ("c", Vec::<(&str, u8)>::new()),
+            t7: ("アップ", vec![("アップル🍎", 5)]),
+        }
+    }
+
+    mod common_prefix_search_tests {
+        macro_rules! parameterized_tests {
+            ($($name:ident: $value:expr,)*) => {
+            $(
+                #[test]
+                fn $name() {
+                    let (query, expected_results) = $value;
+                    let trie = super::build_trie();
+                    let results = trie.common_prefix_search(query);
+                    let expected_results: Vec<(Vec<u8>, u8)> = expected_results.iter().map(|s| (s.0.as_bytes().to_vec(), s.1)).collect();
+                    assert_eq!(results, expected_results);
+                }
+            )*
+            }
+        }
+
+        parameterized_tests! {
+            t1: ("a", vec![("a", 0)]),
+            t2: ("ap", vec![("a", 0)]),
+            t3: ("appl", vec![("a", 0), ("app", 1)]),
+            t4: ("appler", vec![("a", 0), ("app", 1), ("apple", 2)]),
+            t5: ("bette", Vec::<(&str, u8)>::new()),
+            t6: ("betterment", vec![("better", 3)]),
+            t7: ("c", Vec::<(&str, u8)>::new()),
+            t8: ("アップル🍎🍏", vec![("アップル🍎", 5)]),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,3 +185,4 @@ pub use trie::TrieBuilder;
 
 mod internal_data_structure;
 pub mod trie;
+pub mod dict;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![forbid(missing_docs)]
-//! Memory efficient trie (prefix tree) library based on LOUDS.
+//! Memory efficient trie (prefix tree) and map library based on LOUDS.
 //!
 //! [Master API Docs](https://laysakura.github.io/trie-rs/trie_rs/)
 //! |
@@ -162,6 +162,32 @@
 //!     trie.common_prefix_search([1, 4, 1, 5, 9, 2, 6, 5, 3, 5]),
 //!     vec![[1, 4, 1, 5, 9, 2, 6, 5, 3, 5]],
 //! );
+//! ```
+//!
+//! ## Trie Map Usage
+//!
+//! To store a value with each word, use `trie_rs::map::{Trie, TrieBuilder}`.
+//!
+//! ```rust
+//! use std::str;
+//! use trie_rs::map::TrieBuilder;
+//!
+//! let mut builder = TrieBuilder::new();  // Inferred `TrieBuilder<u8, u8>` automatically
+//! builder.push("すし", 0);
+//! builder.push("すしや", 1);
+//! builder.push("すしだね", 2);
+//! builder.push("すしづめ", 3);
+//! builder.push("すしめし", 4);
+//! builder.push("すしをにぎる", 5);
+//! builder.push("すし", 6);  // Word `push`ed twice is just ignored.
+//! builder.push("🍣", 7);
+//!
+//! let trie = builder.build();
+//!
+//! // exact_match(): Find a word exactly match to query.
+//! assert_eq!(trie.exact_match("すし"), Some(0));
+//! assert_eq!(trie.exact_match("🍣"), Some(7));
+//! assert_eq!(trie.exact_match("🍜"), None);
 //! ```
 //!
 //! # Features

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![forbid(missing_docs)]
 //! Memory efficient trie (prefix tree) library based on LOUDS.
 //!
 //! [Master API Docs](https://laysakura.github.io/trie-rs/trie_rs/)
@@ -184,5 +185,5 @@ pub use trie::Trie;
 pub use trie::TrieBuilder;
 
 mod internal_data_structure;
-pub mod trie;
+mod trie;
 pub mod dict;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,4 +186,4 @@ pub use trie::TrieBuilder;
 
 mod internal_data_structure;
 mod trie;
-pub mod dict;
+pub mod map;

--- a/src/map.rs
+++ b/src/map.rs
@@ -1,4 +1,4 @@
-//! A "dictionary" trie, it stores a value with each entry.
+//! A trie map that stores a key and value.
 use crate::{Trie as OldTrie, TrieBuilder as OldTrieBuilder};
 use derivative::Derivative;
 

--- a/src/map.rs
+++ b/src/map.rs
@@ -1,4 +1,4 @@
-//! A trie map that stores a key and value.
+//! A trie map stores a value with each word or key.
 use crate::{Trie as OldTrie, TrieBuilder as OldTrieBuilder};
 use derivative::Derivative;
 
@@ -55,6 +55,7 @@ impl<K: Clone, V: Clone> Trie<K,V> where KeyValue<K,V>: Ord + Clone {
         self.inner.common_prefix_search(q).into_iter().map(|v| Self::strip(v)).collect()
     }
 
+    /// Given a list of `KeyValue`s take the last value and return only the keys.
     fn strip(mut word: Vec<KeyValue<K,V>>) -> (Vec<K>, V) {
         let value = word.last_mut().expect("word should have length > 0").1.clone().expect("Terminal node should have value");
         (word.into_iter().map(|x| x.0).collect(), value)

--- a/src/trie.rs
+++ b/src/trie.rs
@@ -4,6 +4,7 @@ use louds_rs::Louds;
 pub mod trie;
 pub mod trie_builder;
 
+/// A trie for sequences of the type `Label`.
 pub struct Trie<Label> {
     louds: Louds,
 
@@ -11,6 +12,7 @@ pub struct Trie<Label> {
     trie_labels: Vec<TrieLabel<Label>>,
 }
 
+/// A trie builder for [Trie].
 pub struct TrieBuilder<Label> {
     naive_trie: NaiveTrie<Label>,
 }

--- a/src/trie/trie.rs
+++ b/src/trie/trie.rs
@@ -33,21 +33,13 @@ impl<Label: Ord + Clone> Trie<Label> {
         for (i, chr) in query.as_ref().iter().enumerate() {
             let children_node_nums = self.children_node_nums(cur_node_num);
             let res = self.bin_search_by_children_labels(chr, &children_node_nums[..]);
-
             match res {
-                Ok(j) => {
-                    let child_node_num = children_node_nums[j];
-                    if i == query.as_ref().len() - 1 && self.is_terminal(child_node_num) {
-                        // This is a terminal. Is it also a prefix?
-                        return !self.children_node_nums(child_node_num).is_empty();
-                        // return Some(child_node_num);
-                    };
-                    cur_node_num = child_node_num;
-                }
+                Ok(j) => cur_node_num = children_node_nums[j],
                 Err(_) => return false,
             }
         }
-        true
+        // Are there more nodes after our query?
+        !self.children_node_nums(cur_node_num).is_empty()
     }
 
     /// # Panics
@@ -214,6 +206,9 @@ mod search_tests {
             t7: ("appl", true),
             t8: ("appler", false),
             t9: ("アップル", true),
+            t10: ("ed", false),
+            t11: ("e", false),
+            t12: ("", true),
         }
     }
 

--- a/src/trie/trie_builder.rs
+++ b/src/trie/trie_builder.rs
@@ -4,15 +4,18 @@ use crate::{Trie, TrieBuilder};
 use louds_rs::Louds;
 
 impl<Label: Ord + Clone> TrieBuilder<Label> {
+    /// Return a [TrieBuilder].
     pub fn new() -> Self {
         let naive_trie = NaiveTrie::make_root();
         Self { naive_trie }
     }
 
-    pub fn push<Arr: AsRef<[Label]>>(&mut self, word: Arr) {
-        self.naive_trie.push(word);
+    /// Add an entry.
+    pub fn push<Arr: AsRef<[Label]>>(&mut self, entry: Arr) {
+        self.naive_trie.push(entry);
     }
 
+    /// Build a [Trie].
     pub fn build(&self) -> Trie<Label> {
         let mut louds_bits: Vec<bool> = vec![true, false];
         let mut trie_labels: Vec<TrieLabel<Label>> = vec![];


### PR DESCRIPTION
Thank you for making this project and making it available. I added a key-value trie in the map module. I have seen [others](https://crates.io/crates/kv-trie-rs) add this functionality with a whole sale reimplementation. This patch differs in that it doesn't change the original code; it really only adds a facade on top of the existing trie implementation in a separate module. It uses a private struct `KeyValue<K,V>(K, V)` pair where only the key is used for `Eq` and `Ord`.

In addition, I added a `is_prefix()` function. It's merely to avoid an allocation when all one wants is to know whether the given `query` is a prefix.

I added some docs to the public functions.

I did not bump any version numbers.