### PR TITLE
Fix order dep map trie builder

### DIFF
--- a/src/internal_data_structure/naive_trie.rs
+++ b/src/internal_data_structure/naive_trie.rs
@@ -80,6 +80,6 @@ pub struct NaiveTrieRoot<Label> {
 pub struct NaiveTrieIntermOrLeaf<Label> {
     /// Sorted by Label's order.
     children: Vec<Box<NaiveTrie<Label>>>,
-    label: Label,
-    is_terminal: bool,
+    pub(crate) label: Label,
+    pub(crate) is_terminal: bool,
 }

--- a/src/internal_data_structure/naive_trie/naive_trie.rs
+++ b/src/internal_data_structure/naive_trie/naive_trie.rs
@@ -14,7 +14,8 @@ impl<'trie, Label: Ord + Clone> NaiveTrie<Label> {
         }))
     }
 
-    pub fn push<Arr: AsRef<[Label]>>(&'trie mut self, word: Arr) {
+    /// Add a word. Returns the terminal node of the word that can be ignored.
+    pub fn push<Arr: AsRef<[Label]>>(&'trie mut self, word: Arr) -> &'trie mut NaiveTrie<Label> {
         let mut trie = self;
         for (i, chr) in word.as_ref().iter().enumerate() {
             let res = {
@@ -46,6 +47,7 @@ impl<'trie, Label: Ord + Clone> NaiveTrie<Label> {
                 }
             };
         }
+        trie
     }
 
     pub fn bf_iter(&'trie self) -> NaiveTrieBFIter<Label> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,5 +211,5 @@ pub use trie::Trie;
 pub use trie::TrieBuilder;
 
 mod internal_data_structure;
-mod trie;
 pub mod map;
+mod trie;

--- a/src/map.rs
+++ b/src/map.rs
@@ -101,8 +101,30 @@ mod search_tests {
     #[test]
     fn sanity_check() {
         let trie = build_trie();
-        assert_eq!(trie.predictive_search("apple"), vec![("apple".as_bytes().to_vec(), 2)]);
+        assert_eq!(
+            trie.predictive_search("apple"),
+            vec![("apple".as_bytes().to_vec(), 2)]
+        );
+    }
 
+    #[test]
+    fn value_overwrite_long_first() {
+        let mut builder = TrieBuilder::new();
+        builder.push("apple", 2);
+        builder.push("app", 1);
+        let trie = builder.build();
+        assert_eq!(trie.exact_match("apple"), Some(2));
+        assert_eq!(trie.exact_match("app"), Some(1));
+    }
+
+    #[test]
+    fn value_overwrite_short() {
+        let mut builder = TrieBuilder::new();
+        builder.push("app", 1);
+        builder.push("apple", 2);
+        let trie = builder.build();
+        assert_eq!(trie.exact_match("apple"), Some(2));
+        assert_eq!(trie.exact_match("app"), Some(1));
     }
 
     mod exact_match_tests {

--- a/src/map.rs
+++ b/src/map.rs
@@ -72,9 +72,22 @@ impl<K: Clone, V: Clone> TrieBuilder<K,V> where KeyValue<K,V>: Ord + Clone {
 
     /// Add a key and value.
     pub fn push<Arr: AsRef<[K]>>(&mut self, key: Arr, value: V) {
-        let mut v: Vec<KeyValue<K,V>> = key.as_ref().iter().map(|x: &K| KeyValue(x.clone(), None)).collect();
-        v.last_mut().unwrap().1 = Some(value);
-        self.inner.push(v);
+        use crate::internal_data_structure::naive_trie::NaiveTrie;
+        let v: Vec<KeyValue<K, V>> = key
+            .as_ref()
+            .iter()
+            .map(|x: &K| KeyValue(x.clone(), None))
+            .collect();
+        let trie_terminal = self.inner.push(v);
+        match trie_terminal {
+            NaiveTrie::IntermOrLeaf(ref mut node) => {
+                node.label.1 = Some(value.clone());
+                node.is_terminal = true;
+            }
+            _ => {
+                panic!("Expected a interim or leaf node as terminal.");
+            }
+        }
     }
 
     /// Build a [Trie].

--- a/src/trie.rs
+++ b/src/trie.rs
@@ -14,7 +14,7 @@ pub struct Trie<Label> {
 
 /// A trie builder for [Trie].
 pub struct TrieBuilder<Label> {
-    naive_trie: NaiveTrie<Label>,
+    pub(crate) naive_trie: NaiveTrie<Label>,
 }
 
 struct TrieLabel<Label> {

--- a/src/trie.rs
+++ b/src/trie.rs
@@ -14,7 +14,7 @@ pub struct Trie<Label> {
 
 /// A trie builder for [Trie].
 pub struct TrieBuilder<Label> {
-    pub(crate) naive_trie: NaiveTrie<Label>,
+    naive_trie: NaiveTrie<Label>,
 }
 
 struct TrieLabel<Label> {

--- a/src/trie/trie_builder.rs
+++ b/src/trie/trie_builder.rs
@@ -11,8 +11,8 @@ impl<Label: Ord + Clone> TrieBuilder<Label> {
     }
 
     /// Add an entry.
-    pub fn push<Arr: AsRef<[Label]>>(&mut self, entry: Arr) {
-        self.naive_trie.push(entry);
+    pub fn push<Arr: AsRef<[Label]>>(&mut self, entry: Arr) -> &mut NaiveTrie<Label> {
+        self.naive_trie.push(entry)
     }
 
     /// Build a [Trie].


### PR DESCRIPTION
Caught a bug where the order of entries to `map::TrieBuilder` exposed a bug. Namely a long entry like "apple" if it came before a shorter entry "app" then it would not be found.

```
#[test]
    fn value_overwrite_long_first() {
        let mut builder = TrieBuilder::new();
        builder.push("apple", 2);
        builder.push("app", 1);
        let trie = builder.build();
        assert_eq!(trie.exact_match("apple"), Some(2));
        assert_eq!(trie.exact_match("app"), Some(1)); // This one fails.
    }

    #[test]
    fn value_overwrite_short() {
        let mut builder = TrieBuilder::new();
        builder.push("app", 1);
        builder.push("apple", 2);
        let trie = builder.build();
        assert_eq!(trie.exact_match("apple"), Some(2));
        assert_eq!(trie.exact_match("app"), Some(1)); // This one is fine.
    }
```