### PR TITLE
allow passing an iterator into prefix searches, insted of a slice.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ assert_eq!(
 );
 
 // common_prefix_search(): Find words which is included in `query`'s prefix.
-let results_in_u8s: Vec<Vec<u8>> = trie.common_prefix_search("すしや").collect();
-let results_in_str: Vec<String> = trie.common_prefix_search("すしや").collect();
+let results_in_u8s: Vec<Vec<u8>> = trie.common_prefix_search("すしや".bytes()).collect();
+let results_in_str: Vec<String> = trie.common_prefix_search("すしや".bytes()).collect();
 assert_eq!(
     results_in_str,
     vec![

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -219,9 +219,9 @@ mod trie {
                         // Tested function takes too short compared to build().
                         // So loop many times.
                         let results_in_str: Vec<String> =
-                            trie.common_prefix_search("すしをにぎる").collect();
+                            trie.common_prefix_search("すしをにぎる".bytes()).collect();
                         for _ in 0..(times - 1) {
-                            for entry in trie.common_prefix_search("すしをにぎる") {
+                            for entry in trie.common_prefix_search("すしをにぎる".bytes()) {
                                 black_box::<Vec<u8>>(entry);
                             }
                         }
@@ -249,12 +249,12 @@ mod trie {
                         // iter_batched() does not properly time `routine` time when `setup` time is far longer than `routine` time.
                         // Tested function takes too short compared to build(). So loop many times.
                         let result = trie
-                            .common_prefix_search::<Vec<u8>, _>("すしをにぎる")
+                            .common_prefix_search::<Vec<u8>, _, _>("すしをにぎる".bytes())
                             .next()
                             .is_some();
                         for _ in 0..(times - 1) {
                             let _ = trie
-                                .common_prefix_search::<Vec<u8>, _>("すしをにぎる")
+                                .common_prefix_search::<Vec<u8>, _, _>("すしをにぎる".bytes())
                                 .next()
                                 .is_some();
                         }


### PR DESCRIPTION
This PR improves the prefix search functionality by enabling it to accept iterators as input. This change allows you to pass a &mut Iterator to a prefix search, advancing the iterator until a match is found. while also allowing you to pass regular slices.